### PR TITLE
Sprint 4: Experiment Design — Full Feature

### DIFF
--- a/app/src/Routes.tsx
+++ b/app/src/Routes.tsx
@@ -16,6 +16,7 @@ import {
   EvaluatorTracePage,
 } from "@phoenix/pages/dataset/evaluators/EvaluatorTracePage";
 import { DataGenerationPage } from "@phoenix/pages/dataGeneration/DataGenerationPage";
+import { ExperimentDesignPage } from "@phoenix/pages/experimentDesign/ExperimentDesignPage";
 import { EvaluatorsPage } from "@phoenix/pages/evaluators/EvaluatorsPage";
 import { evaluatorsPageLoader } from "@phoenix/pages/evaluators/evaluatorsPageLoader";
 import { RootLayout } from "@phoenix/pages/RootLayout";
@@ -223,6 +224,13 @@ const router = createBrowserRouter(
             element={<DataGenerationPage />}
             handle={{
               crumb: () => "Data Generation",
+            }}
+          />
+          <Route
+            path="/experiment-design"
+            element={<ExperimentDesignPage />}
+            handle={{
+              crumb: () => "Experiment Design",
             }}
           />
           <Route

--- a/app/src/pages/Layout.tsx
+++ b/app/src/pages/Layout.tsx
@@ -133,6 +133,14 @@ function SideNav() {
               isExpanded={isSideNavExpanded}
             />
           </li>
+          <li key="experiment-design">
+            <NavLink
+              to="/experiment-design"
+              text="Experiment Design"
+              leadingVisual={<Icon svg={<Icons.CubeOutline />} />}
+              isExpanded={isSideNavExpanded}
+            />
+          </li>
           <li key="playground">
             <NavLink
               to="/playground"

--- a/app/src/pages/experimentDesign/ExperimentDesignPage.tsx
+++ b/app/src/pages/experimentDesign/ExperimentDesignPage.tsx
@@ -1,0 +1,796 @@
+/**
+ * Experiment Design page — Sprint 4.
+ *
+ * Provides a UI for creating, viewing, and managing factorial experiment designs.
+ * Uses REST API endpoints under /v1/experiment-designs.
+ */
+import { css } from "@emotion/react";
+import {
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import type { ColumnDef } from "@tanstack/react-table";
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
+
+import {
+  Button,
+  Flex,
+  Heading,
+  Icon,
+  Icons,
+  Loading,
+  Text,
+  View,
+} from "@phoenix/components";
+import { tableCSS } from "@phoenix/components/table/styles";
+import { TimestampCell } from "@phoenix/components/table/TimestampCell";
+
+/* ── Shared styles ──────────────────────────────────────────────────────── */
+
+const tabBarCSS = css`
+  display: flex;
+  gap: var(--ac-global-dimension-size-200);
+  border-bottom: 1px solid var(--ac-global-color-grey-300);
+  padding: 0 var(--ac-global-dimension-size-200);
+`;
+
+const tabCSS = css`
+  padding: var(--ac-global-dimension-size-100)
+    var(--ac-global-dimension-size-200);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  color: var(--ac-global-text-color-700);
+  background: none;
+  border-top: none;
+  border-left: none;
+  border-right: none;
+  font-size: var(--ac-global-dimension-font-size-100);
+  &:hover {
+    color: var(--ac-global-text-color-900);
+  }
+`;
+
+const activeTabCSS = css`
+  ${tabCSS};
+  border-bottom-color: var(--ac-global-color-primary);
+  color: var(--ac-global-text-color-900);
+  font-weight: 600;
+`;
+
+const statusBadgeCSS = css`
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 12px;
+  font-weight: 500;
+`;
+
+const cardCSS = css`
+  border: 1px solid var(--ac-global-color-grey-300);
+  border-radius: var(--ac-global-rounding-medium);
+  padding: var(--ac-global-dimension-size-200);
+  cursor: pointer;
+  transition: border-color 0.15s;
+  &:hover {
+    border-color: var(--ac-global-color-primary);
+  }
+`;
+
+const formFieldCSS = css`
+  display: flex;
+  flex-direction: column;
+  gap: var(--ac-global-dimension-size-50);
+  label {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--ac-global-text-color-700);
+  }
+  input,
+  select,
+  textarea {
+    padding: 6px 10px;
+    border: 1px solid var(--ac-global-color-grey-300);
+    border-radius: var(--ac-global-rounding-small);
+    font-size: 14px;
+    background: var(--ac-global-background-color-light);
+    color: var(--ac-global-text-color-900);
+  }
+`;
+
+function StatusBadge({ status }: { status: string }) {
+  const colorMap: Record<string, string> = {
+    draft: "var(--ac-global-color-grey-500)",
+    cells_generated: "var(--ac-global-color-primary)",
+    running: "var(--ac-global-color-primary)",
+    completed: "var(--ac-global-color-green-700)",
+    failed: "var(--ac-global-color-danger)",
+  };
+  const color = colorMap[status] || colorMap.draft;
+  return (
+    <span
+      css={css`
+        ${statusBadgeCSS};
+        color: ${color};
+        border: 1px solid ${color};
+      `}
+    >
+      {status.replace("_", " ")}
+    </span>
+  );
+}
+
+/* ── Types ──────────────────────────────────────────────────────────────── */
+
+interface Factor {
+  id: number;
+  designId: number;
+  name: string;
+  factorType: string;
+  levels: unknown[];
+  createdAt: string;
+}
+
+interface DesignCell {
+  id: number;
+  designId: number;
+  combination: Record<string, unknown>;
+  status: string;
+  experimentId: number | null;
+  resultSummary: Record<string, unknown>;
+  createdAt: string;
+}
+
+interface Design {
+  id: number;
+  name: string;
+  description: string | null;
+  designType: string;
+  status: string;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+  factors: Factor[];
+  cells: DesignCell[];
+}
+
+interface Template {
+  id: string;
+  name: string;
+  description: string;
+}
+
+/* ── REST helpers (camelCase ↔ snake_case) ──────────────────────────────── */
+
+function snakeToCamel(obj: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    const camelKey = key.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+    if (Array.isArray(value)) {
+      out[camelKey] = value.map((v) =>
+        typeof v === "object" && v !== null
+          ? snakeToCamel(v as Record<string, unknown>)
+          : v
+      );
+    } else if (typeof value === "object" && value !== null) {
+      out[camelKey] = snakeToCamel(value as Record<string, unknown>);
+    } else {
+      out[camelKey] = value;
+    }
+  }
+  return out;
+}
+
+async function fetchDesigns(): Promise<Design[]> {
+  const res = await fetch("/v1/experiment-designs");
+  const json = await res.json();
+  return (json.data ?? []).map(
+    (d: Record<string, unknown>) => snakeToCamel(d) as unknown as Design
+  );
+}
+
+async function fetchTemplates(): Promise<Template[]> {
+  const res = await fetch("/v1/experiment-designs/templates");
+  const json = await res.json();
+  return json.data ?? [];
+}
+
+async function createDesignFromTemplate(templateName: string): Promise<Design> {
+  const res = await fetch("/v1/experiment-designs/from-template", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ template_name: templateName }),
+  });
+  const json = await res.json();
+  return snakeToCamel(json.data) as unknown as Design;
+}
+
+async function createDesign(body: {
+  name: string;
+  description?: string;
+  design_type?: string;
+}): Promise<Design> {
+  const res = await fetch("/v1/experiment-designs", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const json = await res.json();
+  return snakeToCamel(json.data) as unknown as Design;
+}
+
+async function generateCells(designId: number): Promise<DesignCell[]> {
+  const res = await fetch(
+    `/v1/experiment-designs/${designId}/generate-cells`,
+    { method: "POST" }
+  );
+  const json = await res.json();
+  return (json.data ?? []).map(
+    (c: Record<string, unknown>) => snakeToCamel(c) as unknown as DesignCell
+  );
+}
+
+async function runDesign(designId: number): Promise<Design> {
+  const res = await fetch(`/v1/experiment-designs/${designId}/run`, {
+    method: "POST",
+  });
+  const json = await res.json();
+  return snakeToCamel(json.data) as unknown as Design;
+}
+
+async function deleteDesign(designId: number): Promise<void> {
+  await fetch(`/v1/experiment-designs/${designId}`, { method: "DELETE" });
+}
+
+/* ── Column definitions ─────────────────────────────────────────────────── */
+
+const designColumns: ColumnDef<Design>[] = [
+  { header: "Name", accessorKey: "name", size: 200 },
+  {
+    header: "Type",
+    accessorKey: "designType",
+    size: 140,
+    cell: ({ getValue }) => (
+      <Text>{(getValue() as string).replace("_", " ")}</Text>
+    ),
+  },
+  {
+    header: "Status",
+    accessorKey: "status",
+    size: 130,
+    cell: ({ getValue }) => <StatusBadge status={getValue() as string} />,
+  },
+  {
+    header: "Factors",
+    accessorKey: "factors",
+    size: 80,
+    cell: ({ getValue }) => <Text>{(getValue() as Factor[]).length}</Text>,
+  },
+  {
+    header: "Cells",
+    accessorKey: "cells",
+    size: 80,
+    cell: ({ getValue }) => <Text>{(getValue() as DesignCell[]).length}</Text>,
+  },
+  {
+    header: "Created",
+    accessorKey: "createdAt",
+    size: 180,
+    cell: ({ getValue }) => <TimestampCell datetime={getValue() as string} />,
+  },
+];
+
+/* ── Page component ─────────────────────────────────────────────────────── */
+
+export function ExperimentDesignPage() {
+  return (
+    <Suspense fallback={<Loading />}>
+      <ExperimentDesignContent />
+    </Suspense>
+  );
+}
+
+function ExperimentDesignContent() {
+  const [activeTab, setActiveTab] = useState<
+    "designs" | "templates" | "detail"
+  >("designs");
+  const [designs, setDesigns] = useState<Design[]>([]);
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const [selectedDesign, setSelectedDesign] = useState<Design | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [d, t] = await Promise.all([fetchDesigns(), fetchTemplates()]);
+      setDesigns(d);
+      setTemplates(t);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const handleCreateFromTemplate = useCallback(
+    async (templateName: string) => {
+      const design = await createDesignFromTemplate(templateName);
+      setSelectedDesign(design);
+      setActiveTab("detail");
+      void refresh();
+    },
+    [refresh]
+  );
+
+  const handleCreateBlank = useCallback(async () => {
+    const design = await createDesign({ name: "New Experiment Design" });
+    setSelectedDesign(design);
+    setActiveTab("detail");
+    void refresh();
+  }, [refresh]);
+
+  const handleDeleteDesign = useCallback(
+    async (designId: number) => {
+      await deleteDesign(designId);
+      setSelectedDesign(null);
+      setActiveTab("designs");
+      void refresh();
+    },
+    [refresh]
+  );
+
+  const handleGenerateCells = useCallback(
+    async (designId: number) => {
+      await generateCells(designId);
+      void refresh();
+      // Refresh the selected design
+      const d = await Promise.all([fetchDesigns()]);
+      const updated = d[0].find((x) => x.id === designId);
+      if (updated) setSelectedDesign(updated);
+    },
+    [refresh]
+  );
+
+  const handleRunDesign = useCallback(
+    async (designId: number) => {
+      const updated = await runDesign(designId);
+      setSelectedDesign(updated);
+      void refresh();
+    },
+    [refresh]
+  );
+
+  if (loading) return <Loading />;
+
+  return (
+    <Flex direction="column" height="100%">
+      {/* Header */}
+      <View
+        padding="size-200"
+        flex="none"
+        borderBottomWidth="thin"
+        borderBottomColor="dark"
+      >
+        <Flex
+          direction="row"
+          justifyContent="space-between"
+          alignItems="center"
+        >
+          <Flex direction="row" alignItems="center" gap="size-100">
+            <Icon svg={<Icons.CubeOutline />} />
+            <Heading level={1}>Experiment Design</Heading>
+          </Flex>
+          <Flex direction="row" gap="size-100">
+            <Button variant="default" size="S" onClick={() => void refresh()}>
+              Refresh
+            </Button>
+            <Button
+              variant="primary"
+              size="S"
+              onClick={() => void handleCreateBlank()}
+            >
+              New Design
+            </Button>
+          </Flex>
+        </Flex>
+      </View>
+
+      {/* Tabs */}
+      <div css={tabBarCSS}>
+        <button
+          css={activeTab === "designs" ? activeTabCSS : tabCSS}
+          onClick={() => {
+            setActiveTab("designs");
+            setSelectedDesign(null);
+          }}
+        >
+          Designs ({designs.length})
+        </button>
+        <button
+          css={activeTab === "templates" ? activeTabCSS : tabCSS}
+          onClick={() => setActiveTab("templates")}
+        >
+          Templates ({templates.length})
+        </button>
+        {selectedDesign && (
+          <button
+            css={activeTab === "detail" ? activeTabCSS : tabCSS}
+            onClick={() => setActiveTab("detail")}
+          >
+            {selectedDesign.name}
+          </button>
+        )}
+      </div>
+
+      {/* Content */}
+      <View flex="1 1 auto" overflow="auto" padding="size-200">
+        {activeTab === "designs" && (
+          <DesignList
+            designs={designs}
+            onSelect={(d) => {
+              setSelectedDesign(d);
+              setActiveTab("detail");
+            }}
+          />
+        )}
+        {activeTab === "templates" && (
+          <TemplateSelector
+            templates={templates}
+            onSelect={handleCreateFromTemplate}
+          />
+        )}
+        {activeTab === "detail" && selectedDesign && (
+          <DesignDetail
+            design={selectedDesign}
+            onDelete={handleDeleteDesign}
+            onGenerateCells={handleGenerateCells}
+            onRun={handleRunDesign}
+          />
+        )}
+      </View>
+    </Flex>
+  );
+}
+
+/* ── Design list ────────────────────────────────────────────────────────── */
+
+function DesignList({
+  designs,
+  onSelect,
+}: {
+  designs: Design[];
+  onSelect: (d: Design) => void;
+}) {
+  if (designs.length === 0) {
+    return (
+      <EmptyState
+        title="No experiment designs"
+        description="Create a design from a template or start from scratch."
+      />
+    );
+  }
+
+  return (
+    <DataTable
+      columns={designColumns}
+      data={designs}
+      onRowClick={(row) => onSelect(row)}
+    />
+  );
+}
+
+/* ── Template selector ──────────────────────────────────────────────────── */
+
+function TemplateSelector({
+  templates,
+  onSelect,
+}: {
+  templates: Template[];
+  onSelect: (templateName: string) => void;
+}) {
+  if (templates.length === 0) {
+    return (
+      <EmptyState
+        title="No templates available"
+        description="Templates will be loaded from the server."
+      />
+    );
+  }
+
+  return (
+    <Flex direction="column" gap="size-200">
+      <Text>
+        Select a pre-built template to quickly configure an experiment design:
+      </Text>
+      <div
+        css={css`
+          display: grid;
+          grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+          gap: var(--ac-global-dimension-size-200);
+        `}
+      >
+        {templates.map((t) => (
+          <div
+            key={t.id}
+            css={cardCSS}
+            role="button"
+            tabIndex={0}
+            onClick={() => onSelect(t.id)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") onSelect(t.id);
+            }}
+          >
+            <Flex direction="column" gap="size-50">
+              <Text weight="heavy">{t.name}</Text>
+              <Text color="text-500">{t.description}</Text>
+            </Flex>
+          </div>
+        ))}
+      </div>
+    </Flex>
+  );
+}
+
+/* ── Design detail (factors + matrix) ───────────────────────────────────── */
+
+function DesignDetail({
+  design,
+  onDelete,
+  onGenerateCells,
+  onRun,
+}: {
+  design: Design;
+  onDelete: (id: number) => void;
+  onGenerateCells: (id: number) => void;
+  onRun: (id: number) => void;
+}) {
+  return (
+    <Flex direction="column" gap="size-200">
+      {/* Design info */}
+      <View
+        padding="size-200"
+        borderWidth="thin"
+        borderColor="dark"
+        borderRadius="medium"
+      >
+        <Flex direction="row" justifyContent="space-between" alignItems="start">
+          <Flex direction="column" gap="size-50">
+            <Heading level={2}>{design.name}</Heading>
+            {design.description && (
+              <Text color="text-500">{design.description}</Text>
+            )}
+            <Flex direction="row" gap="size-200">
+              <Text>
+                Type: <strong>{design.designType.replace("_", " ")}</strong>
+              </Text>
+              <StatusBadge status={design.status} />
+            </Flex>
+          </Flex>
+          <Flex direction="row" gap="size-100">
+            {design.status === "draft" && design.factors.length > 0 && (
+              <Button
+                variant="primary"
+                size="S"
+                onClick={() => onGenerateCells(design.id)}
+              >
+                Generate Cells
+              </Button>
+            )}
+            {(design.status === "cells_generated" ||
+              design.status === "failed") && (
+              <Button
+                variant="primary"
+                size="S"
+                onClick={() => onRun(design.id)}
+              >
+                Run All
+              </Button>
+            )}
+            <Button
+              variant="danger"
+              size="S"
+              onClick={() => onDelete(design.id)}
+            >
+              Delete
+            </Button>
+          </Flex>
+        </Flex>
+      </View>
+
+      {/* Factors */}
+      <View>
+        <Heading level={3}>Factors ({design.factors.length})</Heading>
+        {design.factors.length === 0 ? (
+          <Text color="text-500">
+            No factors defined. Add factors via the API.
+          </Text>
+        ) : (
+          <Flex direction="column" gap="size-100">
+            {design.factors.map((f) => (
+              <View
+                key={f.id}
+                padding="size-100"
+                borderWidth="thin"
+                borderColor="dark"
+                borderRadius="small"
+              >
+                <Flex direction="row" gap="size-200" alignItems="center">
+                  <Text weight="heavy">{f.name}</Text>
+                  <StatusBadge status={f.factorType} />
+                  <Text color="text-500">
+                    {(f.levels ?? []).length} level
+                    {(f.levels ?? []).length !== 1 ? "s" : ""}
+                  </Text>
+                  <Text color="text-500" size="XS">
+                    {(f.levels ?? [])
+                      .map((l: unknown) => {
+                        if (typeof l === "object" && l !== null && "name" in l)
+                          return (l as { name: string }).name;
+                        return JSON.stringify(l);
+                      })
+                      .join(", ")}
+                  </Text>
+                </Flex>
+              </View>
+            ))}
+          </Flex>
+        )}
+      </View>
+
+      {/* Cell matrix */}
+      <ExperimentMatrix cells={design.cells} factors={design.factors} />
+    </Flex>
+  );
+}
+
+/* ── Experiment matrix ──────────────────────────────────────────────────── */
+
+function ExperimentMatrix({
+  cells,
+  factors,
+}: {
+  cells: DesignCell[];
+  factors: Factor[];
+}) {
+  const matrixColumns = useMemo<ColumnDef<DesignCell>[]>(() => {
+    const cols: ColumnDef<DesignCell>[] = factors.map((f) => ({
+      header: f.name,
+      accessorFn: (row: DesignCell) => {
+        const val = row.combination[f.name];
+        if (typeof val === "object" && val !== null && "name" in val) {
+          return (val as { name: string }).name;
+        }
+        return JSON.stringify(val);
+      },
+      size: 160,
+    }));
+    cols.push({
+      header: "Status",
+      accessorKey: "status",
+      size: 120,
+      cell: ({ getValue }) => <StatusBadge status={getValue() as string} />,
+    });
+    return cols;
+  }, [factors]);
+
+  if (cells.length === 0) {
+    return (
+      <View>
+        <Heading level={3}>Cell Matrix</Heading>
+        <Text color="text-500">
+          No cells generated yet. Add factors and generate cells.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View>
+      <Heading level={3}>
+        Cell Matrix ({cells.length} cell{cells.length !== 1 ? "s" : ""})
+      </Heading>
+      <SimpleTable columns={matrixColumns} data={cells} />
+    </View>
+  );
+}
+
+/* ── Reusable table ─────────────────────────────────────────────────────── */
+
+function DataTable<T>({
+  columns,
+  data,
+  onRowClick,
+}: {
+  columns: ColumnDef<T>[];
+  data: T[];
+  onRowClick?: (row: T) => void;
+}) {
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  return (
+    <table css={tableCSS}>
+      <thead>
+        {table.getHeaderGroups().map((hg) => (
+          <tr key={hg.id}>
+            {hg.headers.map((h) => (
+              <th key={h.id} style={{ width: h.getSize() }}>
+                {h.isPlaceholder
+                  ? null
+                  : flexRender(h.column.columnDef.header, h.getContext())}
+              </th>
+            ))}
+          </tr>
+        ))}
+      </thead>
+      <tbody>
+        {table.getRowModel().rows.map((row) => (
+          <tr
+            key={row.id}
+            onClick={() => onRowClick?.(row.original)}
+            css={
+              onRowClick
+                ? css`
+                    cursor: pointer;
+                    &:hover {
+                      background: var(--ac-global-color-grey-100);
+                    }
+                  `
+                : undefined
+            }
+          >
+            {row.getVisibleCells().map((cell) => (
+              <td key={cell.id}>
+                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function SimpleTable<T>({
+  columns,
+  data,
+}: {
+  columns: ColumnDef<T>[];
+  data: T[];
+}) {
+  return <DataTable columns={columns} data={data} />;
+}
+
+/* ── Empty state ────────────────────────────────────────────────────────── */
+
+function EmptyState({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <Flex
+      direction="column"
+      alignItems="center"
+      justifyContent="center"
+      height="100%"
+      gap="size-100"
+    >
+      <Icon
+        svg={<Icons.CubeOutline />}
+        color="var(--ac-global-text-color-500)"
+      />
+      <Heading level={3}>{title}</Heading>
+      <Text color="text-500">{description}</Text>
+    </Flex>
+  );
+}

--- a/app/src/pages/experimentDesign/index.tsx
+++ b/app/src/pages/experimentDesign/index.tsx
@@ -1,0 +1,1 @@
+export { ExperimentDesignPage } from "./ExperimentDesignPage";

--- a/src/phoenix/db/migrations/versions/b2c3d4e5f6a7_add_experiment_design_tables.py
+++ b/src/phoenix/db/migrations/versions/b2c3d4e5f6a7_add_experiment_design_tables.py
@@ -1,0 +1,164 @@
+"""Add experiment design tables (Sprint 4)
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-03-16 12:00:00.000000
+
+"""
+
+from typing import Any, Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import JSON, text
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.ext.compiler import compiles
+
+# revision identifiers, used by Alembic.
+revision: str = "b2c3d4e5f6a7"
+down_revision: Union[str, None] = "a1b2c3d4e5f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+class JSONB(JSON):
+    # See https://docs.sqlalchemy.org/en/20/core/custom_types.html
+    __visit_name__ = "JSONB"
+
+
+@compiles(JSONB, "sqlite")
+def _(*args: Any, **kwargs: Any) -> str:
+    # See https://docs.sqlalchemy.org/en/20/core/custom_types.html
+    return "JSONB"
+
+
+JSON_ = (
+    JSON()
+    .with_variant(
+        postgresql.JSONB(),
+        "postgresql",
+    )
+    .with_variant(
+        JSONB(),
+        "sqlite",
+    )
+)
+
+
+def upgrade() -> None:
+    # --- Experiment Designs ---
+    op.create_table(
+        "experiment_designs",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String, nullable=False),
+        sa.Column("description", sa.String, nullable=True),
+        sa.Column(
+            "design_type",
+            sa.String,
+            nullable=False,
+            server_default=text("'full_factorial'"),
+        ),
+        sa.Column(
+            "status",
+            sa.String,
+            nullable=False,
+            server_default=text("'draft'"),
+        ),
+        sa.Column("metadata", JSON_, nullable=False, server_default=text("'{}'")),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.CheckConstraint(
+            "design_type IN ('full_factorial', 'fractional', 'custom')",
+            name="valid_design_type",
+        ),
+        sa.CheckConstraint(
+            "status IN ('draft', 'cells_generated', 'running', 'completed', 'failed')",
+            name="valid_design_status",
+        ),
+    )
+
+    # --- Experiment Factors ---
+    op.create_table(
+        "experiment_factors",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "design_id",
+            sa.Integer,
+            sa.ForeignKey("experiment_designs.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("name", sa.String, nullable=False),
+        sa.Column(
+            "factor_type",
+            sa.String,
+            nullable=False,
+            server_default=text("'custom'"),
+        ),
+        sa.Column("levels", JSON_, nullable=False, server_default=text("'[]'")),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.CheckConstraint(
+            "factor_type IN ('embedding', 'reranker', 'judge_llm', "
+            "'rag_llm', 'testset_llm', 'custom')",
+            name="valid_factor_type",
+        ),
+    )
+
+    # --- Experiment Design Cells ---
+    op.create_table(
+        "experiment_design_cells",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "design_id",
+            sa.Integer,
+            sa.ForeignKey("experiment_designs.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("combination", JSON_, nullable=False, server_default=text("'{}'")),
+        sa.Column(
+            "status",
+            sa.String,
+            nullable=False,
+            server_default=text("'pending'"),
+        ),
+        sa.Column(
+            "experiment_id",
+            sa.Integer,
+            sa.ForeignKey("experiments.id", ondelete="SET NULL"),
+            nullable=True,
+            index=True,
+        ),
+        sa.Column("result_summary", JSON_, nullable=False, server_default=text("'{}'")),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.CheckConstraint(
+            "status IN ('pending', 'running', 'completed', 'failed')",
+            name="valid_cell_status",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("experiment_design_cells")
+    op.drop_table("experiment_factors")
+    op.drop_table("experiment_designs")

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -2657,3 +2657,147 @@ class EvaluationCriterion(HasId):
 
     def __repr__(self) -> str:
         return f"<EvaluationCriterion {self.name!r} ({self.category})>"
+
+
+# ── Sprint 4: Experiment Design ──────────────────────────────────────────────
+
+
+class ExperimentDesign(HasId):
+    """A factorial experiment design that organises multiple factors and cells.
+
+    Each design generates a matrix of cells (factor-level combinations).
+    Cells link to upstream Phoenix ``Experiment`` rows when executed.
+    """
+
+    __tablename__ = "experiment_designs"
+
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    description: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+
+    design_type: Mapped[str] = mapped_column(
+        CheckConstraint(
+            "design_type IN ('full_factorial', 'fractional', 'custom')",
+            name="valid_design_type",
+        ),
+        nullable=False,
+        server_default=text("'full_factorial'"),
+    )
+
+    status: Mapped[str] = mapped_column(
+        CheckConstraint(
+            "status IN ('draft', 'cells_generated', 'running', 'completed', 'failed')",
+            name="valid_design_status",
+        ),
+        nullable=False,
+        server_default=text("'draft'"),
+    )
+
+    metadata_: Mapped[dict[str, Any]] = mapped_column("metadata", JSON_)
+
+    created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        UtcTimeStamp, server_default=func.now(), onupdate=func.now()
+    )
+
+    # Relationships
+    factors: Mapped[list["ExperimentFactor"]] = relationship(
+        "ExperimentFactor",
+        back_populates="design",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
+    cells: Mapped[list["ExperimentDesignCell"]] = relationship(
+        "ExperimentDesignCell",
+        back_populates="design",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
+
+    def __repr__(self) -> str:
+        return f"<ExperimentDesign {self.name!r} type={self.design_type} status={self.status}>"
+
+
+class ExperimentFactor(HasId):
+    """A single factor (variable) in an experiment design.
+
+    Each factor has a type and a JSON array of levels.  For example a
+    ``factor_type='embedding'`` factor might have levels
+    ``[{"name": "text-embedding-3-small"}, {"name": "text-embedding-ada-002"}]``.
+    """
+
+    __tablename__ = "experiment_factors"
+
+    design_id: Mapped[int] = mapped_column(
+        ForeignKey("experiment_designs.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    name: Mapped[str] = mapped_column(String, nullable=False)
+
+    factor_type: Mapped[str] = mapped_column(
+        CheckConstraint(
+            "factor_type IN ('embedding', 'reranker', 'judge_llm', "
+            "'rag_llm', 'testset_llm', 'custom')",
+            name="valid_factor_type",
+        ),
+        nullable=False,
+        server_default=text("'custom'"),
+    )
+
+    levels: Mapped[list[Any]] = mapped_column(JSON_)  # JSON array of level defs
+
+    created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
+
+    # Relationships
+    design: Mapped["ExperimentDesign"] = relationship(
+        "ExperimentDesign", back_populates="factors"
+    )
+
+    def __repr__(self) -> str:
+        return f"<ExperimentFactor {self.name!r} type={self.factor_type}>"
+
+
+class ExperimentDesignCell(HasId):
+    """A single cell in the experiment matrix.
+
+    Stores the factor-level combination as JSON and optionally links to the
+    upstream Phoenix ``Experiment`` row once the cell is executed.
+    """
+
+    __tablename__ = "experiment_design_cells"
+
+    design_id: Mapped[int] = mapped_column(
+        ForeignKey("experiment_designs.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    combination: Mapped[dict[str, Any]] = mapped_column(JSON_)  # {factor_name: level}
+
+    status: Mapped[str] = mapped_column(
+        CheckConstraint(
+            "status IN ('pending', 'running', 'completed', 'failed')",
+            name="valid_cell_status",
+        ),
+        nullable=False,
+        server_default=text("'pending'"),
+    )
+
+    experiment_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("experiments.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
+    result_summary: Mapped[dict[str, Any]] = mapped_column(JSON_)
+
+    created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
+
+    # Relationships
+    design: Mapped["ExperimentDesign"] = relationship(
+        "ExperimentDesign", back_populates="cells"
+    )
+
+    def __repr__(self) -> str:
+        return f"<ExperimentDesignCell design_id={self.design_id} status={self.status}>"

--- a/src/phoenix/server/api/mutations/__init__.py
+++ b/src/phoenix/server/api/mutations/__init__.py
@@ -13,6 +13,9 @@ from phoenix.server.api.mutations.document_annotations_mutations import (
     DocumentAnnotationMutationMixin,
 )
 from phoenix.server.api.mutations.evaluator_mutations import EvaluatorMutationMixin
+from phoenix.server.api.mutations.experiment_design_mutations import (
+    ExperimentDesignMutationMixin,
+)
 from phoenix.server.api.mutations.experiment_mutations import ExperimentMutationMixin
 from phoenix.server.api.mutations.generative_model_custom_provider_mutations import (
     GenerativeModelCustomProviderMutationMixin,
@@ -46,6 +49,7 @@ class Mutation(
     DatasetSplitMutationMixin,
     DocumentAnnotationMutationMixin,
     EvaluatorMutationMixin,
+    ExperimentDesignMutationMixin,
     ExperimentMutationMixin,
     GenerativeModelCustomProviderMutationMixin,
     ModelMutationMixin,

--- a/src/phoenix/server/api/mutations/experiment_design_mutations.py
+++ b/src/phoenix/server/api/mutations/experiment_design_mutations.py
@@ -1,0 +1,268 @@
+"""Strawberry GraphQL mutations for Experiment Design management."""
+
+import itertools
+from typing import Any, Optional
+
+import strawberry
+from sqlalchemy import delete, select
+from strawberry.relay import GlobalID
+from strawberry.scalars import JSON
+from strawberry.types import Info
+
+from phoenix.db import models
+from phoenix.server.api.auth import IsNotReadOnly, IsNotViewer
+from phoenix.server.api.context import Context
+from phoenix.server.api.exceptions import BadRequest, NotFound
+from phoenix.server.api.types.ExperimentDesign import (
+    ExperimentDesign,
+    ExperimentDesignCell,
+    ExperimentFactor,
+    to_gql_experiment_design,
+    to_gql_experiment_design_cell,
+    to_gql_experiment_factor,
+)
+from phoenix.server.api.types.node import from_global_id_with_expected_type
+
+
+# --- Input types ---
+
+
+@strawberry.input
+class CreateExperimentDesignInput:
+    name: str
+    description: Optional[str] = None
+    design_type: str = "full_factorial"
+    metadata: JSON = strawberry.field(default_factory=dict)
+
+
+@strawberry.input
+class DeleteExperimentDesignInput:
+    design_id: GlobalID
+
+
+@strawberry.input
+class AddExperimentFactorInput:
+    design_id: GlobalID
+    name: str
+    factor_type: str = "custom"
+    levels: JSON = strawberry.field(default_factory=list)
+
+
+@strawberry.input
+class RemoveExperimentFactorInput:
+    factor_id: GlobalID
+
+
+@strawberry.input
+class GenerateExperimentCellsInput:
+    design_id: GlobalID
+
+
+@strawberry.input
+class RunExperimentDesignInput:
+    design_id: GlobalID
+
+
+# --- Payload types ---
+
+
+@strawberry.type
+class ExperimentDesignMutationPayload:
+    design: ExperimentDesign
+
+
+@strawberry.type
+class ExperimentFactorMutationPayload:
+    factor: ExperimentFactor
+
+
+@strawberry.type
+class GenerateCellsPayload:
+    cells: list[ExperimentDesignCell]
+    design: ExperimentDesign
+
+
+# --- Mutation mixin ---
+
+
+@strawberry.type
+class ExperimentDesignMutationMixin:
+    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer])  # type: ignore
+    async def create_experiment_design(
+        self,
+        info: Info[Context, None],
+        input: CreateExperimentDesignInput,
+    ) -> ExperimentDesignMutationPayload:
+        valid_types = ("full_factorial", "fractional", "custom")
+        if input.design_type not in valid_types:
+            raise BadRequest(f"design_type must be one of {valid_types}")
+
+        async with info.context.db() as session:
+            design = models.ExperimentDesign(
+                name=input.name,
+                description=input.description,
+                design_type=input.design_type,
+                metadata_=input.metadata or {},
+            )
+            session.add(design)
+            await session.flush()
+            await session.refresh(design, ["created_at", "updated_at"])
+            return ExperimentDesignMutationPayload(
+                design=to_gql_experiment_design(design)
+            )
+
+    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer])  # type: ignore
+    async def delete_experiment_design(
+        self,
+        info: Info[Context, None],
+        input: DeleteExperimentDesignInput,
+    ) -> ExperimentDesignMutationPayload:
+        design_id = from_global_id_with_expected_type(
+            input.design_id, ExperimentDesign.__name__
+        )
+        async with info.context.db() as session:
+            design = await session.get(models.ExperimentDesign, int(design_id))
+            if design is None:
+                raise NotFound(f"ExperimentDesign {design_id} not found")
+            gql_design = to_gql_experiment_design(design)
+            await session.delete(design)
+            await session.flush()
+            return ExperimentDesignMutationPayload(design=gql_design)
+
+    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer])  # type: ignore
+    async def add_experiment_factor(
+        self,
+        info: Info[Context, None],
+        input: AddExperimentFactorInput,
+    ) -> ExperimentFactorMutationPayload:
+        design_id = from_global_id_with_expected_type(
+            input.design_id, ExperimentDesign.__name__
+        )
+        valid_types = ("embedding", "reranker", "judge_llm", "rag_llm", "testset_llm", "custom")
+        if input.factor_type not in valid_types:
+            raise BadRequest(f"factor_type must be one of {valid_types}")
+
+        async with info.context.db() as session:
+            design = await session.get(models.ExperimentDesign, int(design_id))
+            if design is None:
+                raise NotFound(f"ExperimentDesign {design_id} not found")
+            factor = models.ExperimentFactor(
+                design_id=int(design_id),
+                name=input.name,
+                factor_type=input.factor_type,
+                levels=input.levels or [],
+            )
+            session.add(factor)
+            await session.flush()
+            await session.refresh(factor, ["created_at"])
+            return ExperimentFactorMutationPayload(
+                factor=to_gql_experiment_factor(factor)
+            )
+
+    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer])  # type: ignore
+    async def remove_experiment_factor(
+        self,
+        info: Info[Context, None],
+        input: RemoveExperimentFactorInput,
+    ) -> ExperimentFactorMutationPayload:
+        factor_id = from_global_id_with_expected_type(
+            input.factor_id, ExperimentFactor.__name__
+        )
+        async with info.context.db() as session:
+            factor = await session.get(models.ExperimentFactor, int(factor_id))
+            if factor is None:
+                raise NotFound(f"ExperimentFactor {factor_id} not found")
+            gql_factor = to_gql_experiment_factor(factor)
+            await session.delete(factor)
+            await session.flush()
+            return ExperimentFactorMutationPayload(factor=gql_factor)
+
+    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer])  # type: ignore
+    async def generate_experiment_cells(
+        self,
+        info: Info[Context, None],
+        input: GenerateExperimentCellsInput,
+    ) -> GenerateCellsPayload:
+        design_id = from_global_id_with_expected_type(
+            input.design_id, ExperimentDesign.__name__
+        )
+        async with info.context.db() as session:
+            design = await session.get(models.ExperimentDesign, int(design_id))
+            if design is None:
+                raise NotFound(f"ExperimentDesign {design_id} not found")
+
+            if not design.factors:
+                raise BadRequest("Design must have at least one factor with levels")
+
+            for f in design.factors:
+                if not f.levels:
+                    raise BadRequest(f"Factor '{f.name}' has no levels defined")
+
+            # Clear existing cells
+            await session.execute(
+                delete(models.ExperimentDesignCell).where(
+                    models.ExperimentDesignCell.design_id == int(design_id)
+                )
+            )
+            await session.flush()
+
+            # Compute full factorial
+            factor_names = [f.name for f in design.factors]
+            factor_levels = [f.levels for f in design.factors]
+
+            cells = []
+            for combo in itertools.product(*factor_levels):
+                combination = dict(zip(factor_names, combo))
+                cell = models.ExperimentDesignCell(
+                    design_id=int(design_id),
+                    combination=combination,
+                    result_summary={},
+                )
+                session.add(cell)
+                cells.append(cell)
+
+            await session.flush()
+            for cell in cells:
+                await session.refresh(cell, ["created_at"])
+
+            design.status = "cells_generated"
+            await session.flush()
+            await session.refresh(design, ["updated_at"])
+
+            return GenerateCellsPayload(
+                cells=[to_gql_experiment_design_cell(c) for c in cells],
+                design=to_gql_experiment_design(design),
+            )
+
+    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer])  # type: ignore
+    async def run_experiment_design(
+        self,
+        info: Info[Context, None],
+        input: RunExperimentDesignInput,
+    ) -> ExperimentDesignMutationPayload:
+        design_id = from_global_id_with_expected_type(
+            input.design_id, ExperimentDesign.__name__
+        )
+        async with info.context.db() as session:
+            design = await session.get(models.ExperimentDesign, int(design_id))
+            if design is None:
+                raise NotFound(f"ExperimentDesign {design_id} not found")
+
+            if design.status not in ("cells_generated", "failed"):
+                raise BadRequest(
+                    f"Cannot run design in status '{design.status}'. Generate cells first."
+                )
+
+            if not design.cells:
+                raise BadRequest("No cells to run. Generate cells first.")
+
+            design.status = "running"
+            for cell in design.cells:
+                if cell.status != "completed":
+                    cell.status = "pending"
+            await session.flush()
+            await session.refresh(design, ["updated_at"])
+
+            return ExperimentDesignMutationPayload(
+                design=to_gql_experiment_design(design)
+            )

--- a/src/phoenix/server/api/routers/v1/__init__.py
+++ b/src/phoenix/server/api/routers/v1/__init__.py
@@ -10,6 +10,7 @@ from .data_generation import router as data_generation_router
 from .datasets import router as datasets_router
 from .documents import router as documents_router
 from .evaluations import router as evaluations_router
+from .experiment_design import router as experiment_design_router
 from .experiment_evaluations import router as experiment_evaluations_router
 from .experiment_runs import router as experiment_runs_router
 from .experiments import router as experiments_router
@@ -84,6 +85,7 @@ def create_v1_router(authentication_enabled: bool) -> APIRouter:
     router.include_router(data_generation_router)
     router.include_router(datasets_router)
     router.include_router(experiments_router)
+    router.include_router(experiment_design_router)
     router.include_router(experiment_runs_router)
     router.include_router(experiment_evaluations_router)
     router.include_router(traces_router)

--- a/src/phoenix/server/api/routers/v1/experiment_design.py
+++ b/src/phoenix/server/api/routers/v1/experiment_design.py
@@ -1,0 +1,558 @@
+"""REST API router for Experiment Design management.
+
+Provides CRUD operations, factorial cell generation, and run-all for
+experiment designs. See Sprint 4 of the MetroStar dev plan.
+"""
+
+import itertools
+import logging
+from datetime import datetime
+from typing import Any, Optional
+
+from fastapi import APIRouter, HTTPException, Query
+from sqlalchemy import delete, select
+from sqlalchemy.orm import selectinload
+from starlette.requests import Request
+from starlette.status import (
+    HTTP_404_NOT_FOUND,
+    HTTP_409_CONFLICT,
+    HTTP_422_UNPROCESSABLE_ENTITY,
+)
+
+from phoenix.db import models
+
+from .models import V1RoutesBaseModel
+from .utils import ResponseBody, add_errors_to_responses
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/experiment-designs", tags=["experiment-designs"])
+
+
+# ── Pydantic response / request models ──────────────────────────────────────
+
+
+class ExperimentFactor(V1RoutesBaseModel):
+    id: int
+    design_id: int
+    name: str
+    factor_type: str
+    levels: list[Any]
+    created_at: datetime
+
+
+class ExperimentDesignCell(V1RoutesBaseModel):
+    id: int
+    design_id: int
+    combination: dict[str, Any]
+    status: str
+    experiment_id: Optional[int]
+    result_summary: dict[str, Any]
+    created_at: datetime
+
+
+class ExperimentDesign(V1RoutesBaseModel):
+    id: int
+    name: str
+    description: Optional[str]
+    design_type: str
+    status: str
+    metadata: dict[str, Any]
+    created_at: datetime
+    updated_at: datetime
+    factors: list[ExperimentFactor]
+    cells: list[ExperimentDesignCell]
+
+
+class CreateExperimentDesignRequest(V1RoutesBaseModel):
+    name: str
+    description: Optional[str] = None
+    design_type: str = "full_factorial"
+    metadata: dict[str, Any] = {}
+
+
+class AddFactorRequest(V1RoutesBaseModel):
+    name: str
+    factor_type: str = "custom"
+    levels: list[Any] = []
+
+
+class CreateFromTemplateRequest(V1RoutesBaseModel):
+    template_name: str
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _factor_to_response(f: models.ExperimentFactor) -> ExperimentFactor:
+    return ExperimentFactor(
+        id=f.id,
+        design_id=f.design_id,
+        name=f.name,
+        factor_type=f.factor_type,
+        levels=f.levels if f.levels else [],
+        created_at=f.created_at,
+    )
+
+
+def _cell_to_response(c: models.ExperimentDesignCell) -> ExperimentDesignCell:
+    return ExperimentDesignCell(
+        id=c.id,
+        design_id=c.design_id,
+        combination=c.combination or {},
+        status=c.status,
+        experiment_id=c.experiment_id,
+        result_summary=c.result_summary or {},
+        created_at=c.created_at,
+    )
+
+
+def _to_response(d: models.ExperimentDesign) -> ExperimentDesign:
+    return ExperimentDesign(
+        id=d.id,
+        name=d.name,
+        description=d.description,
+        design_type=d.design_type,
+        status=d.status,
+        metadata=d.metadata_ or {},
+        created_at=d.created_at,
+        updated_at=d.updated_at,
+        factors=[_factor_to_response(f) for f in (d.factors or [])],
+        cells=[_cell_to_response(c) for c in (d.cells or [])],
+    )
+
+
+async def _load_design_with_rels(
+    session: Any, design_id: int
+) -> models.ExperimentDesign | None:
+    """Load an ExperimentDesign with factors and cells eagerly loaded.
+
+    Uses an explicit SELECT with selectinload to guarantee relationships
+    are populated, avoiding MissingGreenlet errors from lazy loading.
+    """
+    stmt = (
+        select(models.ExperimentDesign)
+        .where(models.ExperimentDesign.id == design_id)
+        .options(
+            selectinload(models.ExperimentDesign.factors),
+            selectinload(models.ExperimentDesign.cells),
+        )
+        .execution_options(populate_existing=True)
+    )
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+# ── CRUD Endpoints ──────────────────────────────────────────────────────────
+
+
+@router.post(
+    "",
+    operation_id="createExperimentDesign",
+    summary="Create a new experiment design",
+    responses=add_errors_to_responses([]),
+)
+async def create_experiment_design(
+    request: Request,
+    body: CreateExperimentDesignRequest,
+) -> ResponseBody[ExperimentDesign]:
+    valid_types = ("full_factorial", "fractional", "custom")
+    if body.design_type not in valid_types:
+        raise HTTPException(
+            status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"design_type must be one of {valid_types}",
+        )
+    async with request.app.state.db() as session:
+        design = models.ExperimentDesign(
+            name=body.name,
+            description=body.description,
+            design_type=body.design_type,
+            metadata_=body.metadata or {},
+        )
+        session.add(design)
+        await session.flush()
+        # Re-fetch with eager loading for relationships
+        design = await _load_design_with_rels(session, design.id)
+        assert design is not None
+        return ResponseBody(data=_to_response(design))
+
+
+@router.get(
+    "",
+    operation_id="listExperimentDesigns",
+    summary="List experiment designs",
+    responses=add_errors_to_responses([]),
+)
+async def list_experiment_designs(
+    request: Request,
+    status: Optional[str] = Query(None, description="Filter by status"),
+) -> ResponseBody[list[ExperimentDesign]]:
+    async with request.app.state.db() as session:
+        stmt = (
+            select(models.ExperimentDesign)
+            .order_by(models.ExperimentDesign.created_at.desc())
+            .options(
+                selectinload(models.ExperimentDesign.factors),
+                selectinload(models.ExperimentDesign.cells),
+            )
+        )
+        if status:
+            stmt = stmt.where(models.ExperimentDesign.status == status)
+        result = await session.execute(stmt)
+        designs = result.scalars().unique().all()
+        return ResponseBody(data=[_to_response(d) for d in designs])
+
+
+# ── Template routes (MUST come before /{design_id} to avoid path conflict) ──
+
+# Template definitions
+_TEMPLATES: dict[str, dict[str, Any]] = {
+    "8-way-3-factor-rag": {
+        "name": "8-Way 3-Factor RAG",
+        "description": "Full factorial 2×2×2 design: embedding × reranker × LLM",
+        "design_type": "full_factorial",
+        "factors": [
+            {
+                "name": "embedding",
+                "factor_type": "embedding",
+                "levels": [
+                    {"name": "text-embedding-3-small"},
+                    {"name": "text-embedding-ada-002"},
+                ],
+            },
+            {
+                "name": "reranker",
+                "factor_type": "reranker",
+                "levels": [
+                    {"name": "cohere-rerank-v3"},
+                    {"name": "none", "ablation": True},
+                ],
+            },
+            {
+                "name": "rag_llm",
+                "factor_type": "rag_llm",
+                "levels": [
+                    {"name": "gpt-4o"},
+                    {"name": "gpt-4o-mini"},
+                ],
+            },
+        ],
+    },
+    "embedding-comparison": {
+        "name": "Embedding Comparison",
+        "description": "Single-factor comparison of embedding models",
+        "design_type": "full_factorial",
+        "factors": [
+            {
+                "name": "embedding",
+                "factor_type": "embedding",
+                "levels": [
+                    {"name": "text-embedding-3-small"},
+                    {"name": "text-embedding-3-large"},
+                    {"name": "text-embedding-ada-002"},
+                ],
+            },
+        ],
+    },
+    "ablation-study": {
+        "name": "Ablation Study",
+        "description": "Reranker and retrieval ablation baselines",
+        "design_type": "full_factorial",
+        "factors": [
+            {
+                "name": "reranker",
+                "factor_type": "reranker",
+                "levels": [
+                    {"name": "cohere-rerank-v3"},
+                    {"name": "bge-reranker-v2-m3"},
+                    {"name": "none", "ablation": True},
+                ],
+            },
+            {
+                "name": "rag_llm",
+                "factor_type": "rag_llm",
+                "levels": [
+                    {"name": "gpt-4o"},
+                    {"name": "none", "ablation": True},
+                ],
+            },
+        ],
+    },
+}
+
+
+@router.get(
+    "/templates",
+    operation_id="listExperimentDesignTemplates",
+    summary="List available experiment design templates",
+    responses=add_errors_to_responses([]),
+)
+async def list_templates(
+    request: Request,
+) -> ResponseBody[list[dict[str, Any]]]:
+    summaries = [
+        {"id": k, "name": v["name"], "description": v["description"]}
+        for k, v in _TEMPLATES.items()
+    ]
+    return ResponseBody(data=summaries)
+
+
+@router.post(
+    "/from-template",
+    operation_id="createExperimentDesignFromTemplate",
+    summary="Create an experiment design from a pre-built template",
+    responses=add_errors_to_responses([HTTP_404_NOT_FOUND]),
+)
+async def create_from_template(
+    request: Request,
+    body: CreateFromTemplateRequest,
+) -> ResponseBody[ExperimentDesign]:
+    tpl = _TEMPLATES.get(body.template_name)
+    if tpl is None:
+        raise HTTPException(
+            status_code=HTTP_404_NOT_FOUND,
+            detail=f"Template '{body.template_name}' not found. "
+            f"Available: {list(_TEMPLATES.keys())}",
+        )
+
+    async with request.app.state.db() as session:
+        design = models.ExperimentDesign(
+            name=tpl["name"],
+            description=tpl["description"],
+            design_type=tpl["design_type"],
+            metadata_={"template": body.template_name},
+        )
+        session.add(design)
+        await session.flush()
+
+        for fdef in tpl["factors"]:
+            factor = models.ExperimentFactor(
+                design_id=design.id,
+                name=fdef["name"],
+                factor_type=fdef["factor_type"],
+                levels=fdef["levels"],
+            )
+            session.add(factor)
+
+        await session.flush()
+        # Re-fetch with eager loading to get relationships
+        design = await _load_design_with_rels(session, design.id)
+        assert design is not None
+        return ResponseBody(data=_to_response(design))
+
+
+# ── Individual design routes (after static routes) ──────────────────────────
+
+
+@router.get(
+    "/{design_id}",
+    operation_id="getExperimentDesign",
+    summary="Get an experiment design by ID (with factors and cells)",
+    responses=add_errors_to_responses([HTTP_404_NOT_FOUND]),
+)
+async def get_experiment_design(
+    request: Request,
+    design_id: int,
+) -> ResponseBody[ExperimentDesign]:
+    async with request.app.state.db() as session:
+        design = await _load_design_with_rels(session, design_id)
+        if design is None:
+            raise HTTPException(
+                status_code=HTTP_404_NOT_FOUND, detail="Experiment design not found"
+            )
+        return ResponseBody(data=_to_response(design))
+
+
+@router.delete(
+    "/{design_id}",
+    operation_id="deleteExperimentDesign",
+    summary="Delete an experiment design",
+    responses=add_errors_to_responses([HTTP_404_NOT_FOUND]),
+)
+async def delete_experiment_design(
+    request: Request,
+    design_id: int,
+) -> ResponseBody[dict[str, bool]]:
+    async with request.app.state.db() as session:
+        design = await session.get(models.ExperimentDesign, design_id)
+        if design is None:
+            raise HTTPException(
+                status_code=HTTP_404_NOT_FOUND, detail="Experiment design not found"
+            )
+        await session.delete(design)
+        await session.flush()
+        return ResponseBody(data={"deleted": True})
+
+
+# ── Factor management ────────────────────────────────────────────────────────
+
+
+@router.post(
+    "/{design_id}/factors",
+    operation_id="addExperimentFactor",
+    summary="Add a factor to an experiment design",
+    responses=add_errors_to_responses([HTTP_404_NOT_FOUND]),
+)
+async def add_factor(
+    request: Request,
+    design_id: int,
+    body: AddFactorRequest,
+) -> ResponseBody[ExperimentFactor]:
+    valid_types = ("embedding", "reranker", "judge_llm", "rag_llm", "testset_llm", "custom")
+    if body.factor_type not in valid_types:
+        raise HTTPException(
+            status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"factor_type must be one of {valid_types}",
+        )
+    async with request.app.state.db() as session:
+        design = await session.get(models.ExperimentDesign, design_id)
+        if design is None:
+            raise HTTPException(
+                status_code=HTTP_404_NOT_FOUND, detail="Experiment design not found"
+            )
+        factor = models.ExperimentFactor(
+            design_id=design_id,
+            name=body.name,
+            factor_type=body.factor_type,
+            levels=body.levels or [],
+        )
+        session.add(factor)
+        await session.flush()
+        await session.refresh(factor, ["created_at"])
+        return ResponseBody(data=_factor_to_response(factor))
+
+
+@router.delete(
+    "/{design_id}/factors/{factor_id}",
+    operation_id="removeExperimentFactor",
+    summary="Remove a factor from an experiment design",
+    responses=add_errors_to_responses([HTTP_404_NOT_FOUND]),
+)
+async def remove_factor(
+    request: Request,
+    design_id: int,
+    factor_id: int,
+) -> ResponseBody[dict[str, bool]]:
+    async with request.app.state.db() as session:
+        factor = await session.get(models.ExperimentFactor, factor_id)
+        if factor is None or factor.design_id != design_id:
+            raise HTTPException(
+                status_code=HTTP_404_NOT_FOUND, detail="Factor not found in this design"
+            )
+        await session.delete(factor)
+        await session.flush()
+        return ResponseBody(data={"deleted": True})
+
+
+# ── Cell generation ──────────────────────────────────────────────────────────
+
+
+@router.post(
+    "/{design_id}/generate-cells",
+    operation_id="generateExperimentCells",
+    summary="Compute factorial combinations and create cells",
+    responses=add_errors_to_responses([HTTP_404_NOT_FOUND, HTTP_409_CONFLICT]),
+)
+async def generate_cells(
+    request: Request,
+    design_id: int,
+) -> ResponseBody[list[ExperimentDesignCell]]:
+    async with request.app.state.db() as session:
+        design = await _load_design_with_rels(session, design_id)
+        if design is None:
+            raise HTTPException(
+                status_code=HTTP_404_NOT_FOUND, detail="Experiment design not found"
+            )
+
+        if not design.factors:
+            raise HTTPException(
+                status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Design must have at least one factor with levels",
+            )
+
+        # Validate each factor has at least one level
+        for f in design.factors:
+            if not f.levels:
+                raise HTTPException(
+                    status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=f"Factor '{f.name}' has no levels defined",
+                )
+
+        # Clear existing cells
+        await session.execute(
+            delete(models.ExperimentDesignCell).where(
+                models.ExperimentDesignCell.design_id == design_id
+            )
+        )
+        await session.flush()
+
+        # Compute full factorial
+        factor_names = [f.name for f in design.factors]
+        factor_levels = [f.levels for f in design.factors]
+
+        cells = []
+        for combo in itertools.product(*factor_levels):
+            combination = dict(zip(factor_names, combo))
+            cell = models.ExperimentDesignCell(
+                design_id=design_id,
+                combination=combination,
+                result_summary={},
+            )
+            session.add(cell)
+            cells.append(cell)
+
+        await session.flush()
+
+        # Refresh cells to get server defaults
+        for cell in cells:
+            await session.refresh(cell, ["created_at"])
+
+        # Update design status
+        design.status = "cells_generated"
+        await session.flush()
+
+        return ResponseBody(data=[_cell_to_response(c) for c in cells])
+
+
+# ── Run ──────────────────────────────────────────────────────────────────────
+
+
+@router.post(
+    "/{design_id}/run",
+    operation_id="runExperimentDesign",
+    summary="Queue all cells for execution",
+    responses=add_errors_to_responses([HTTP_404_NOT_FOUND, HTTP_409_CONFLICT]),
+)
+async def run_experiment_design(
+    request: Request,
+    design_id: int,
+) -> ResponseBody[ExperimentDesign]:
+    async with request.app.state.db() as session:
+        design = await _load_design_with_rels(session, design_id)
+        if design is None:
+            raise HTTPException(
+                status_code=HTTP_404_NOT_FOUND, detail="Experiment design not found"
+            )
+
+        if design.status not in ("cells_generated", "failed"):
+            raise HTTPException(
+                status_code=HTTP_409_CONFLICT,
+                detail=f"Cannot run design in status '{design.status}'. "
+                "Generate cells first.",
+            )
+
+        if not design.cells:
+            raise HTTPException(
+                status_code=HTTP_409_CONFLICT,
+                detail="No cells to run. Generate cells first.",
+            )
+
+        design.status = "running"
+        for cell in design.cells:
+            if cell.status != "completed":
+                cell.status = "pending"
+        await session.flush()
+        # Re-fetch with eager loading after status change
+        design = await _load_design_with_rels(session, design.id)
+        assert design is not None
+        return ResponseBody(data=_to_response(design))

--- a/src/phoenix/server/api/types/ExperimentDesign.py
+++ b/src/phoenix/server/api/types/ExperimentDesign.py
@@ -1,0 +1,222 @@
+"""Strawberry GraphQL type for ExperimentDesign, ExperimentFactor, and ExperimentDesignCell."""
+
+from datetime import datetime
+from typing import Any, Optional
+
+import strawberry
+from strawberry.relay import Node, NodeID
+from strawberry.scalars import JSON
+from strawberry.types import Info
+
+from phoenix.db import models
+from phoenix.server.api.context import Context
+
+
+@strawberry.type
+class ExperimentDesignCell(Node):
+    id: NodeID[int]
+    db_record: strawberry.Private[Optional[models.ExperimentDesignCell]] = None
+
+    @strawberry.field
+    async def design_id(self, info: Info[Context, None]) -> int:
+        if self.db_record:
+            return self.db_record.design_id
+        async with info.context.db() as session:
+            cell = await session.get(models.ExperimentDesignCell, self.id)
+            assert cell is not None
+            return cell.design_id
+
+    @strawberry.field
+    async def combination(self, info: Info[Context, None]) -> JSON:
+        if self.db_record:
+            return self.db_record.combination
+        async with info.context.db() as session:
+            cell = await session.get(models.ExperimentDesignCell, self.id)
+            assert cell is not None
+            return cell.combination
+
+    @strawberry.field
+    async def status(self, info: Info[Context, None]) -> str:
+        if self.db_record:
+            return self.db_record.status
+        async with info.context.db() as session:
+            cell = await session.get(models.ExperimentDesignCell, self.id)
+            assert cell is not None
+            return cell.status
+
+    @strawberry.field
+    async def experiment_id(self, info: Info[Context, None]) -> Optional[int]:
+        if self.db_record:
+            return self.db_record.experiment_id
+        async with info.context.db() as session:
+            cell = await session.get(models.ExperimentDesignCell, self.id)
+            assert cell is not None
+            return cell.experiment_id
+
+    @strawberry.field
+    async def result_summary(self, info: Info[Context, None]) -> JSON:
+        if self.db_record:
+            return self.db_record.result_summary
+        async with info.context.db() as session:
+            cell = await session.get(models.ExperimentDesignCell, self.id)
+            assert cell is not None
+            return cell.result_summary
+
+    @strawberry.field
+    async def created_at(self, info: Info[Context, None]) -> datetime:
+        if self.db_record:
+            return self.db_record.created_at
+        async with info.context.db() as session:
+            cell = await session.get(models.ExperimentDesignCell, self.id)
+            assert cell is not None
+            return cell.created_at
+
+
+@strawberry.type
+class ExperimentFactor(Node):
+    id: NodeID[int]
+    db_record: strawberry.Private[Optional[models.ExperimentFactor]] = None
+
+    @strawberry.field
+    async def design_id(self, info: Info[Context, None]) -> int:
+        if self.db_record:
+            return self.db_record.design_id
+        async with info.context.db() as session:
+            factor = await session.get(models.ExperimentFactor, self.id)
+            assert factor is not None
+            return factor.design_id
+
+    @strawberry.field
+    async def name(self, info: Info[Context, None]) -> str:
+        if self.db_record:
+            return self.db_record.name
+        async with info.context.db() as session:
+            factor = await session.get(models.ExperimentFactor, self.id)
+            assert factor is not None
+            return factor.name
+
+    @strawberry.field
+    async def factor_type(self, info: Info[Context, None]) -> str:
+        if self.db_record:
+            return self.db_record.factor_type
+        async with info.context.db() as session:
+            factor = await session.get(models.ExperimentFactor, self.id)
+            assert factor is not None
+            return factor.factor_type
+
+    @strawberry.field
+    async def levels(self, info: Info[Context, None]) -> JSON:
+        if self.db_record:
+            return self.db_record.levels
+        async with info.context.db() as session:
+            factor = await session.get(models.ExperimentFactor, self.id)
+            assert factor is not None
+            return factor.levels
+
+    @strawberry.field
+    async def created_at(self, info: Info[Context, None]) -> datetime:
+        if self.db_record:
+            return self.db_record.created_at
+        async with info.context.db() as session:
+            factor = await session.get(models.ExperimentFactor, self.id)
+            assert factor is not None
+            return factor.created_at
+
+
+@strawberry.type
+class ExperimentDesign(Node):
+    id: NodeID[int]
+    db_record: strawberry.Private[Optional[models.ExperimentDesign]] = None
+
+    @strawberry.field
+    async def name(self, info: Info[Context, None]) -> str:
+        if self.db_record:
+            return self.db_record.name
+        async with info.context.db() as session:
+            design = await session.get(models.ExperimentDesign, self.id)
+            assert design is not None
+            return design.name
+
+    @strawberry.field
+    async def description(self, info: Info[Context, None]) -> Optional[str]:
+        if self.db_record:
+            return self.db_record.description
+        async with info.context.db() as session:
+            design = await session.get(models.ExperimentDesign, self.id)
+            assert design is not None
+            return design.description
+
+    @strawberry.field
+    async def design_type(self, info: Info[Context, None]) -> str:
+        if self.db_record:
+            return self.db_record.design_type
+        async with info.context.db() as session:
+            design = await session.get(models.ExperimentDesign, self.id)
+            assert design is not None
+            return design.design_type
+
+    @strawberry.field
+    async def status(self, info: Info[Context, None]) -> str:
+        if self.db_record:
+            return self.db_record.status
+        async with info.context.db() as session:
+            design = await session.get(models.ExperimentDesign, self.id)
+            assert design is not None
+            return design.status
+
+    @strawberry.field
+    async def metadata(self, info: Info[Context, None]) -> JSON:
+        if self.db_record:
+            return self.db_record.metadata_
+        async with info.context.db() as session:
+            design = await session.get(models.ExperimentDesign, self.id)
+            assert design is not None
+            return design.metadata_
+
+    @strawberry.field
+    async def created_at(self, info: Info[Context, None]) -> datetime:
+        if self.db_record:
+            return self.db_record.created_at
+        async with info.context.db() as session:
+            design = await session.get(models.ExperimentDesign, self.id)
+            assert design is not None
+            return design.created_at
+
+    @strawberry.field
+    async def updated_at(self, info: Info[Context, None]) -> datetime:
+        if self.db_record:
+            return self.db_record.updated_at
+        async with info.context.db() as session:
+            design = await session.get(models.ExperimentDesign, self.id)
+            assert design is not None
+            return design.updated_at
+
+    @strawberry.field
+    async def factors(self, info: Info[Context, None]) -> list[ExperimentFactor]:
+        if self.db_record and self.db_record.factors is not None:
+            return [to_gql_experiment_factor(f) for f in self.db_record.factors]
+        async with info.context.db() as session:
+            design = await session.get(models.ExperimentDesign, self.id)
+            assert design is not None
+            return [to_gql_experiment_factor(f) for f in (design.factors or [])]
+
+    @strawberry.field
+    async def cells(self, info: Info[Context, None]) -> list[ExperimentDesignCell]:
+        if self.db_record and self.db_record.cells is not None:
+            return [to_gql_experiment_design_cell(c) for c in self.db_record.cells]
+        async with info.context.db() as session:
+            design = await session.get(models.ExperimentDesign, self.id)
+            assert design is not None
+            return [to_gql_experiment_design_cell(c) for c in (design.cells or [])]
+
+
+def to_gql_experiment_design(design: models.ExperimentDesign) -> ExperimentDesign:
+    return ExperimentDesign(id=design.id, db_record=design)
+
+
+def to_gql_experiment_factor(factor: models.ExperimentFactor) -> ExperimentFactor:
+    return ExperimentFactor(id=factor.id, db_record=factor)
+
+
+def to_gql_experiment_design_cell(cell: models.ExperimentDesignCell) -> ExperimentDesignCell:
+    return ExperimentDesignCell(id=cell.id, db_record=cell)

--- a/tests/unit/server/api/mutations/test_experiment_design_mutations.py
+++ b/tests/unit/server/api/mutations/test_experiment_design_mutations.py
@@ -1,0 +1,357 @@
+"""Unit tests for Experiment Design GraphQL mutations.
+
+Tests the ExperimentDesignMutationMixin: createExperimentDesign,
+deleteExperimentDesign, addExperimentFactor, removeExperimentFactor,
+generateExperimentCells, runExperimentDesign.
+"""
+
+from typing import Any
+
+import pytest
+from sqlalchemy import insert, select
+from strawberry.relay import GlobalID
+
+from phoenix.db import models
+from phoenix.server.types import DbSessionFactory
+from tests.unit.graphql import AsyncGraphQLClient
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+async def _insert_design(
+    db: DbSessionFactory,
+    *,
+    name: str = "test-design",
+    design_type: str = "full_factorial",
+    status: str = "draft",
+) -> int:
+    async with db() as session:
+        design = models.ExperimentDesign(
+            name=name,
+            design_type=design_type,
+            status=status,
+            metadata_={},
+        )
+        session.add(design)
+        await session.flush()
+        return design.id
+
+
+async def _insert_factor(
+    db: DbSessionFactory,
+    *,
+    design_id: int,
+    name: str = "embedding",
+    factor_type: str = "embedding",
+    levels: list[Any] | None = None,
+) -> int:
+    async with db() as session:
+        factor = models.ExperimentFactor(
+            design_id=design_id,
+            name=name,
+            factor_type=factor_type,
+            levels=levels if levels is not None else [{"name": "a"}, {"name": "b"}],
+        )
+        session.add(factor)
+        await session.flush()
+        return factor.id
+
+
+def _gid(type_name: str, db_id: int) -> str:
+    return str(GlobalID(type_name=type_name, node_id=str(db_id)))
+
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+
+
+class TestCreateExperimentDesignMutation:
+    _MUTATION = """
+        mutation CreateExperimentDesign($input: CreateExperimentDesignInput!) {
+            createExperimentDesign(input: $input) {
+                design {
+                    id
+                    name
+                    designType
+                    status
+                }
+            }
+        }
+    """
+
+    async def test_create_design(
+        self,
+        db: DbSessionFactory,
+        gql_client: AsyncGraphQLClient,
+    ) -> None:
+        result = await gql_client.execute(
+            self._MUTATION,
+            variables={
+                "input": {
+                    "name": "GQL Design",
+                    "designType": "full_factorial",
+                }
+            },
+        )
+        assert not result.errors
+        design = result.data["createExperimentDesign"]["design"]
+        assert design["name"] == "GQL Design"
+        assert design["designType"] == "full_factorial"
+        assert design["status"] == "draft"
+
+    async def test_create_invalid_type(
+        self,
+        db: DbSessionFactory,
+        gql_client: AsyncGraphQLClient,
+    ) -> None:
+        result = await gql_client.execute(
+            self._MUTATION,
+            variables={
+                "input": {
+                    "name": "Bad",
+                    "designType": "invalid_type",
+                }
+            },
+        )
+        assert result.errors
+
+
+class TestDeleteExperimentDesignMutation:
+    _MUTATION = """
+        mutation DeleteExperimentDesign($input: DeleteExperimentDesignInput!) {
+            deleteExperimentDesign(input: $input) {
+                design {
+                    id
+                    name
+                }
+            }
+        }
+    """
+
+    async def test_delete_existing(
+        self,
+        db: DbSessionFactory,
+        gql_client: AsyncGraphQLClient,
+    ) -> None:
+        design_id = await _insert_design(db, name="delete-me")
+        result = await gql_client.execute(
+            self._MUTATION,
+            variables={
+                "input": {
+                    "designId": _gid("ExperimentDesign", design_id),
+                }
+            },
+        )
+        assert not result.errors
+        assert result.data["deleteExperimentDesign"]["design"]["name"] == "delete-me"
+
+    async def test_delete_not_found(
+        self,
+        db: DbSessionFactory,
+        gql_client: AsyncGraphQLClient,
+    ) -> None:
+        result = await gql_client.execute(
+            self._MUTATION,
+            variables={
+                "input": {
+                    "designId": _gid("ExperimentDesign", 99999),
+                }
+            },
+        )
+        assert result.errors
+
+
+class TestAddExperimentFactorMutation:
+    _MUTATION = """
+        mutation AddExperimentFactor($input: AddExperimentFactorInput!) {
+            addExperimentFactor(input: $input) {
+                factor {
+                    id
+                    name
+                    factorType
+                    levels
+                }
+            }
+        }
+    """
+
+    async def test_add_factor(
+        self,
+        db: DbSessionFactory,
+        gql_client: AsyncGraphQLClient,
+    ) -> None:
+        design_id = await _insert_design(db)
+        result = await gql_client.execute(
+            self._MUTATION,
+            variables={
+                "input": {
+                    "designId": _gid("ExperimentDesign", design_id),
+                    "name": "embedding",
+                    "factorType": "embedding",
+                    "levels": [{"name": "ada"}, {"name": "small"}],
+                }
+            },
+        )
+        assert not result.errors
+        factor = result.data["addExperimentFactor"]["factor"]
+        assert factor["name"] == "embedding"
+        assert factor["factorType"] == "embedding"
+        assert len(factor["levels"]) == 2
+
+
+class TestRemoveExperimentFactorMutation:
+    _MUTATION = """
+        mutation RemoveExperimentFactor($input: RemoveExperimentFactorInput!) {
+            removeExperimentFactor(input: $input) {
+                factor {
+                    id
+                    name
+                }
+            }
+        }
+    """
+
+    async def test_remove_factor(
+        self,
+        db: DbSessionFactory,
+        gql_client: AsyncGraphQLClient,
+    ) -> None:
+        design_id = await _insert_design(db)
+        factor_id = await _insert_factor(db, design_id=design_id)
+        result = await gql_client.execute(
+            self._MUTATION,
+            variables={
+                "input": {
+                    "factorId": _gid("ExperimentFactor", factor_id),
+                }
+            },
+        )
+        assert not result.errors
+
+
+class TestGenerateExperimentCellsMutation:
+    _MUTATION = """
+        mutation GenerateExperimentCells($input: GenerateExperimentCellsInput!) {
+            generateExperimentCells(input: $input) {
+                cells {
+                    id
+                    combination
+                    status
+                }
+                design {
+                    id
+                    status
+                }
+            }
+        }
+    """
+
+    async def test_generate_2x2_gives_4_cells(
+        self,
+        db: DbSessionFactory,
+        gql_client: AsyncGraphQLClient,
+    ) -> None:
+        design_id = await _insert_design(db)
+        await _insert_factor(
+            db,
+            design_id=design_id,
+            name="embedding",
+            levels=[{"name": "a"}, {"name": "b"}],
+        )
+        await _insert_factor(
+            db,
+            design_id=design_id,
+            name="reranker",
+            factor_type="reranker",
+            levels=[{"name": "x"}, {"name": "y"}],
+        )
+        result = await gql_client.execute(
+            self._MUTATION,
+            variables={
+                "input": {
+                    "designId": _gid("ExperimentDesign", design_id),
+                }
+            },
+        )
+        assert not result.errors
+        cells = result.data["generateExperimentCells"]["cells"]
+        assert len(cells) == 4
+        # Design status updated
+        design = result.data["generateExperimentCells"]["design"]
+        assert design["status"] == "cells_generated"
+
+    async def test_generate_no_factors_fails(
+        self,
+        db: DbSessionFactory,
+        gql_client: AsyncGraphQLClient,
+    ) -> None:
+        design_id = await _insert_design(db)
+        result = await gql_client.execute(
+            self._MUTATION,
+            variables={
+                "input": {
+                    "designId": _gid("ExperimentDesign", design_id),
+                }
+            },
+        )
+        assert result.errors
+
+
+class TestRunExperimentDesignMutation:
+    _RUN_MUTATION = """
+        mutation RunExperimentDesign($input: RunExperimentDesignInput!) {
+            runExperimentDesign(input: $input) {
+                design {
+                    id
+                    status
+                }
+            }
+        }
+    """
+
+    _GENERATE_MUTATION = """
+        mutation GenerateExperimentCells($input: GenerateExperimentCellsInput!) {
+            generateExperimentCells(input: $input) {
+                cells { id }
+                design { id status }
+            }
+        }
+    """
+
+    async def test_run_after_generate(
+        self,
+        db: DbSessionFactory,
+        gql_client: AsyncGraphQLClient,
+    ) -> None:
+        design_id = await _insert_design(db)
+        await _insert_factor(db, design_id=design_id)
+        # Generate first
+        await gql_client.execute(
+            self._GENERATE_MUTATION,
+            variables={
+                "input": {"designId": _gid("ExperimentDesign", design_id)}
+            },
+        )
+        # Then run
+        result = await gql_client.execute(
+            self._RUN_MUTATION,
+            variables={
+                "input": {"designId": _gid("ExperimentDesign", design_id)}
+            },
+        )
+        assert not result.errors
+        assert result.data["runExperimentDesign"]["design"]["status"] == "running"
+
+    async def test_run_draft_fails(
+        self,
+        db: DbSessionFactory,
+        gql_client: AsyncGraphQLClient,
+    ) -> None:
+        design_id = await _insert_design(db, status="draft")
+        result = await gql_client.execute(
+            self._RUN_MUTATION,
+            variables={
+                "input": {"designId": _gid("ExperimentDesign", design_id)}
+            },
+        )
+        assert result.errors

--- a/tests/unit/server/api/routers/v1/test_experiment_design.py
+++ b/tests/unit/server/api/routers/v1/test_experiment_design.py
@@ -1,0 +1,484 @@
+"""Unit tests for the Experiment Design REST API router (/v1/experiment-designs)."""
+
+from typing import Any
+
+import httpx
+import pytest
+
+from phoenix.db import models
+from phoenix.server.types import DbSessionFactory
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+async def _insert_design(
+    db: DbSessionFactory,
+    *,
+    name: str = "test-design",
+    design_type: str = "full_factorial",
+    status: str = "draft",
+    **kwargs: Any,
+) -> int:
+    async with db() as session:
+        design = models.ExperimentDesign(
+            name=name,
+            design_type=design_type,
+            status=status,
+            metadata_=kwargs.get("metadata_", {}),
+        )
+        session.add(design)
+        await session.flush()
+        return design.id
+
+
+async def _insert_factor(
+    db: DbSessionFactory,
+    *,
+    design_id: int,
+    name: str = "embedding",
+    factor_type: str = "embedding",
+    levels: list[Any] | None = None,
+) -> int:
+    async with db() as session:
+        factor = models.ExperimentFactor(
+            design_id=design_id,
+            name=name,
+            factor_type=factor_type,
+            levels=levels if levels is not None else [{"name": "a"}, {"name": "b"}],
+        )
+        session.add(factor)
+        await session.flush()
+        return factor.id
+
+
+# ── CRUD Tests ───────────────────────────────────────────────────────────────
+
+
+class TestCreateExperimentDesign:
+    async def test_create_design(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        response = await httpx_client.post(
+            "v1/experiment-designs",
+            json={"name": "My Design", "design_type": "full_factorial"},
+        )
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert data["name"] == "My Design"
+        assert data["design_type"] == "full_factorial"
+        assert data["status"] == "draft"
+
+    async def test_create_design_invalid_type(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        response = await httpx_client.post(
+            "v1/experiment-designs",
+            json={"name": "Bad", "design_type": "invalid"},
+        )
+        assert response.status_code == 422
+
+
+class TestListExperimentDesigns:
+    async def test_empty_list(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        response = await httpx_client.get("v1/experiment-designs")
+        assert response.status_code == 200
+        assert response.json()["data"] == []
+
+    async def test_returns_designs(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        await _insert_design(db, name="design-a")
+        await _insert_design(db, name="design-b")
+        response = await httpx_client.get("v1/experiment-designs")
+        assert response.status_code == 200
+        assert len(response.json()["data"]) == 2
+
+    async def test_filter_by_status(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        await _insert_design(db, name="d1", status="draft")
+        await _insert_design(db, name="d2", status="completed")
+        response = await httpx_client.get(
+            "v1/experiment-designs", params={"status": "draft"}
+        )
+        assert response.status_code == 200
+        assert len(response.json()["data"]) == 1
+        assert response.json()["data"][0]["name"] == "d1"
+
+
+class TestGetExperimentDesign:
+    async def test_get_existing(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        design_id = await _insert_design(db, name="get-me")
+        response = await httpx_client.get(f"v1/experiment-designs/{design_id}")
+        assert response.status_code == 200
+        assert response.json()["data"]["name"] == "get-me"
+
+    async def test_get_not_found(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        response = await httpx_client.get("v1/experiment-designs/99999")
+        assert response.status_code == 404
+
+
+class TestDeleteExperimentDesign:
+    async def test_delete_existing(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        design_id = await _insert_design(db, name="delete-me")
+        response = await httpx_client.delete(
+            f"v1/experiment-designs/{design_id}"
+        )
+        assert response.status_code == 200
+        assert response.json()["data"]["deleted"] is True
+        # Verify gone
+        response = await httpx_client.get(f"v1/experiment-designs/{design_id}")
+        assert response.status_code == 404
+
+    async def test_delete_not_found(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        response = await httpx_client.delete("v1/experiment-designs/99999")
+        assert response.status_code == 404
+
+
+# ── Factor management ────────────────────────────────────────────────────────
+
+
+class TestAddFactor:
+    async def test_add_factor(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        design_id = await _insert_design(db)
+        response = await httpx_client.post(
+            f"v1/experiment-designs/{design_id}/factors",
+            json={
+                "name": "embedding",
+                "factor_type": "embedding",
+                "levels": [{"name": "ada"}, {"name": "small"}],
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert data["name"] == "embedding"
+        assert data["factor_type"] == "embedding"
+        assert len(data["levels"]) == 2
+
+    async def test_add_factor_design_not_found(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        response = await httpx_client.post(
+            "v1/experiment-designs/99999/factors",
+            json={"name": "x", "factor_type": "custom", "levels": []},
+        )
+        assert response.status_code == 404
+
+    async def test_add_factor_invalid_type(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        design_id = await _insert_design(db)
+        response = await httpx_client.post(
+            f"v1/experiment-designs/{design_id}/factors",
+            json={"name": "x", "factor_type": "INVALID_TYPE", "levels": []},
+        )
+        assert response.status_code == 422
+
+
+class TestRemoveFactor:
+    async def test_remove_factor(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        design_id = await _insert_design(db)
+        factor_id = await _insert_factor(db, design_id=design_id)
+        response = await httpx_client.delete(
+            f"v1/experiment-designs/{design_id}/factors/{factor_id}"
+        )
+        assert response.status_code == 200
+        assert response.json()["data"]["deleted"] is True
+
+    async def test_remove_factor_not_found(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        design_id = await _insert_design(db)
+        response = await httpx_client.delete(
+            f"v1/experiment-designs/{design_id}/factors/99999"
+        )
+        assert response.status_code == 404
+
+
+# ── Cell generation ──────────────────────────────────────────────────────────
+
+
+class TestGenerateCells:
+    async def test_generate_2x2x2_gives_8_cells(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        """Three binary factors → 2³ = 8 cells."""
+        design_id = await _insert_design(db)
+        await _insert_factor(
+            db,
+            design_id=design_id,
+            name="embedding",
+            factor_type="embedding",
+            levels=[{"name": "ada"}, {"name": "small"}],
+        )
+        await _insert_factor(
+            db,
+            design_id=design_id,
+            name="reranker",
+            factor_type="reranker",
+            levels=[{"name": "cohere"}, {"name": "none"}],
+        )
+        await _insert_factor(
+            db,
+            design_id=design_id,
+            name="rag_llm",
+            factor_type="rag_llm",
+            levels=[{"name": "gpt-4o"}, {"name": "gpt-4o-mini"}],
+        )
+
+        response = await httpx_client.post(
+            f"v1/experiment-designs/{design_id}/generate-cells"
+        )
+        assert response.status_code == 200
+        cells = response.json()["data"]
+        assert len(cells) == 8
+
+        # Verify unique combinations (use json serialization for hashability)
+        import json
+        combos = [json.dumps(c["combination"], sort_keys=True) for c in cells]
+        assert len(set(combos)) == 8
+
+    async def test_generate_single_factor_3_levels(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        """Single factor with 3 levels → 3 cells."""
+        design_id = await _insert_design(db)
+        await _insert_factor(
+            db,
+            design_id=design_id,
+            name="embedding",
+            factor_type="embedding",
+            levels=[{"name": "a"}, {"name": "b"}, {"name": "c"}],
+        )
+        response = await httpx_client.post(
+            f"v1/experiment-designs/{design_id}/generate-cells"
+        )
+        assert response.status_code == 200
+        assert len(response.json()["data"]) == 3
+
+    async def test_generate_updates_status(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        design_id = await _insert_design(db)
+        await _insert_factor(db, design_id=design_id)
+        await httpx_client.post(
+            f"v1/experiment-designs/{design_id}/generate-cells"
+        )
+        # Check design status updated
+        response = await httpx_client.get(f"v1/experiment-designs/{design_id}")
+        assert response.json()["data"]["status"] == "cells_generated"
+
+    async def test_generate_no_factors_fails(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        design_id = await _insert_design(db)
+        response = await httpx_client.post(
+            f"v1/experiment-designs/{design_id}/generate-cells"
+        )
+        assert response.status_code == 422
+
+    async def test_generate_factor_no_levels_fails(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        design_id = await _insert_design(db)
+        await _insert_factor(
+            db, design_id=design_id, name="empty", levels=[]
+        )
+        response = await httpx_client.post(
+            f"v1/experiment-designs/{design_id}/generate-cells"
+        )
+        assert response.status_code == 422
+
+    async def test_regenerate_clears_old_cells(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        """Re-generating cells replaces old ones."""
+        design_id = await _insert_design(db)
+        await _insert_factor(db, design_id=design_id)
+        # First generation
+        r1 = await httpx_client.post(
+            f"v1/experiment-designs/{design_id}/generate-cells"
+        )
+        assert len(r1.json()["data"]) == 2
+        # Second generation
+        r2 = await httpx_client.post(
+            f"v1/experiment-designs/{design_id}/generate-cells"
+        )
+        assert len(r2.json()["data"]) == 2
+        # Verify only 2 cells total
+        detail = await httpx_client.get(f"v1/experiment-designs/{design_id}")
+        assert len(detail.json()["data"]["cells"]) == 2
+
+
+# ── Run ──────────────────────────────────────────────────────────────────────
+
+
+class TestRunDesign:
+    async def test_run_after_generate(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        design_id = await _insert_design(db)
+        await _insert_factor(db, design_id=design_id)
+        await httpx_client.post(
+            f"v1/experiment-designs/{design_id}/generate-cells"
+        )
+        response = await httpx_client.post(
+            f"v1/experiment-designs/{design_id}/run"
+        )
+        assert response.status_code == 200
+        assert response.json()["data"]["status"] == "running"
+
+    async def test_run_draft_fails(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        design_id = await _insert_design(db, status="draft")
+        response = await httpx_client.post(
+            f"v1/experiment-designs/{design_id}/run"
+        )
+        assert response.status_code == 409
+
+    async def test_run_not_found(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        response = await httpx_client.post("v1/experiment-designs/99999/run")
+        assert response.status_code == 404
+
+
+# ── Templates ────────────────────────────────────────────────────────────────
+
+
+class TestTemplates:
+    async def test_list_templates(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        response = await httpx_client.get("v1/experiment-designs/templates")
+        assert response.status_code == 200
+        templates = response.json()["data"]
+        assert len(templates) >= 3
+        names = [t["name"] for t in templates]
+        assert "8-Way 3-Factor RAG" in names
+        assert "Embedding Comparison" in names
+        assert "Ablation Study" in names
+
+    async def test_create_from_template_8way(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        response = await httpx_client.post(
+            "v1/experiment-designs/from-template",
+            json={"template_name": "8-way-3-factor-rag"},
+        )
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert data["name"] == "8-Way 3-Factor RAG"
+        assert len(data["factors"]) == 3
+        assert data["design_type"] == "full_factorial"
+
+    async def test_create_from_template_not_found(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        response = await httpx_client.post(
+            "v1/experiment-designs/from-template",
+            json={"template_name": "nonexistent"},
+        )
+        assert response.status_code == 404
+
+    async def test_template_generates_8_cells(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        """8-Way template → 3 binary factors → 8 cells."""
+        create = await httpx_client.post(
+            "v1/experiment-designs/from-template",
+            json={"template_name": "8-way-3-factor-rag"},
+        )
+        design_id = create.json()["data"]["id"]
+        gen = await httpx_client.post(
+            f"v1/experiment-designs/{design_id}/generate-cells"
+        )
+        assert gen.status_code == 200
+        assert len(gen.json()["data"]) == 8
+
+    async def test_ablation_template_generates_6_cells(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        """Ablation template → 3×2 = 6 cells."""
+        create = await httpx_client.post(
+            "v1/experiment-designs/from-template",
+            json={"template_name": "ablation-study"},
+        )
+        design_id = create.json()["data"]["id"]
+        gen = await httpx_client.post(
+            f"v1/experiment-designs/{design_id}/generate-cells"
+        )
+        assert gen.status_code == 200
+        assert len(gen.json()["data"]) == 6


### PR DESCRIPTION
## Sprint 4: Experiment Design

### Summary
Full-stack implementation of the Experiment Design feature for MetroStar Phoenix — enabling users to create factorial experiment designs, manage factors/levels, generate combinatorial cells, and run experiments.

### Changes

**Database (closes #8)**
- 3 new models: `ExperimentDesign`, `ExperimentFactor`, `ExperimentDesignCell`
- Alembic migration `b2c3d4e5f6a7`
- Full factorial, fractional, and custom design types
- Status workflow: draft → cells_generated → running → completed/failed

**REST API (closes #9)**
- 10 endpoints on `/v1/experiment-designs`
- CRUD for designs, factor management, cell generation, run
- Status filtering on list endpoint

**Templates (closes #10)**
- 3 built-in templates: `8-way-3-factor-rag` (2³=8 cells), `embedding-comparison` (3 levels), `ablation-study` (3×2=6 cells)
- GET `/templates` and POST `/from-template` endpoints

**Frontend UI (closes #11)**
- `ExperimentDesignPage` with tabbed interface (designs / templates / detail)
- `ExperimentMatrix` visualization, `DesignList`, `TemplateSelector` components
- Sidebar navigation with CubeOutline icon

**Tests (closes #12)**
- 28 router tests covering all endpoints + edge cases
- 10 GraphQL mutation tests
- All 38 new tests passing; 27 Sprint 3 regression tests also passing

### Key Technical Notes
- Uses `selectinload` with `populate_existing=True` for async relationship loading (avoids MissingGreenlet)
- Static routes (`/templates`, `/from-template`) registered before parameterized `/{design_id}` to prevent route conflicts
- Full factorial cell generation via `itertools.product`

### Test Results
```
Router tests:    28 passed, 28 skipped (PostgreSQL)
Mutation tests:  10 passed, 10 skipped (PostgreSQL)
Sprint 3 tests:  27 passed (regression check)
```
